### PR TITLE
Token Feedback (protocol version2) + Blacklist xmlrpc methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ These methods can be called on the server you started the server on. Be sure you
           Array(Array(Datetime(time_expired), String(token)), ...)
           
 
+### blacklist
+
+      Arguments
+          app_id        String            the application id to retrieve
+		                                          retrieve blacklisted 
+												  (invalid) tokens for
+	
+	  Returns
+		  Array(String(token), ...)
+
+
 ### The Python API
 pyapns also provides a Python API that makes the use of pyapns even simpler. The Python API must be configured before use but configuration files make it easier. The pyapns `client` module currently supports configuration from Django settings and Pylons config. To configure using Django, the following must be present in  your settings file:
 
@@ -192,6 +203,21 @@ Each of these functions can be called synchronously and asynchronously. To make 
 
     Returns:
         List of feedback tuples like [(datetime_expired, token_str), ...]
+
+### `pyapns.client.blacklist(app_id, async=False, callback=None, errback=None)`
+
+    Retrieves a list of blacklisted (invalid) tokens from the pyapns server.
+
+    Arguments:
+        app_id                 the app_id to query
+        async                  pass something truthy to execute the request in 
+                               a background thread
+        callback               a function to be executed with the result 
+        errback                a function to be executed with the error if there
+                               is one during the request
+
+    Returns:
+        List of blacklisted token strings like [String(token), ...]
 
 
 ## The Ruby API

--- a/pyapns/__init__.py
+++ b/pyapns/__init__.py
@@ -1,1 +1,1 @@
-from .client import notify, provision, feedback, configure__version__ = "0.4.0"__author__ = "Samuel Sutch"__license__ = "MIT"__copyright__ = "Copyrighit 2012 Samuel Sutch"
+from .client import notify, provision, feedback, blacklist, configure__version__ = "0.4.0"__author__ = "Samuel Sutch"__license__ = "MIT"__copyright__ = "Copyrighit 2012 Samuel Sutch"

--- a/pyapns/client.py
+++ b/pyapns/client.py
@@ -110,6 +110,18 @@ def feedback(app_id, async=False, callback=None, errback=None):
   t.daemon = True
   t.start()
 
+
+@default_callback
+@reprovision_and_retry
+def blacklist(app_id, async=False, callback=None, errback=None):
+  args = [app_id]
+  f_args = ['blacklist', args, callback, errback]
+  if not async:
+    return _xmlrpc_thread(*f_args)
+  t = threading.Thread(target=_xmlrpc_thread, args=f_args)
+  t.daemon = True
+  t.start()
+    
 def _xmlrpc_thread(method, args, callback, errback=None):
   if not configure({}):
     raise APNSNotConfigured('APNS Has not been configured.')

--- a/pyapns/server.py
+++ b/pyapns/server.py
@@ -333,7 +333,20 @@ class APNSServer(xmlrpc.XMLRPC):
     
     return self.apns_service(app_id).read().addCallback(
       lambda r: decode_feedback(r))
-
+  
+  def xmlrpc_blacklist(self, app_id):
+    """ Queries blacklisted (invalid) tokens. Returns a list of token Strings. The List in pyapns will be cleared.
+    
+      Arguments:
+          app_id    the app_id to query
+      Returns:
+          Blacklisted token Strings as List
+    """
+    
+    if bad_tokens.get(app_id, None):
+      return bad_tokens.pop(app_id)
+    else:
+      return []
 
 def encode_notifications(tokens, notifications, expirys, appId):
   """ Returns the encoded bytes of tokens and notifications

--- a/ruby-client/pyapns/lib/pyapns.rb
+++ b/ruby-client/pyapns/lib/pyapns.rb
@@ -15,8 +15,8 @@ module PYAPNS
   ## PYAPNS::Client
   ## There's python in my ruby!
   ##
-  ## This is a class used to send notifications, provision applications and
-  ## retrieve feedback using the Apple Push Notification Service.
+  ## This is a class used to send notifications, provision applications query invalid tokens
+  ## and retrieve feedback using the Apple Push Notification Service.
   ##
   ## PYAPNS is a multi-application APS provider, meaning it is possible to send
   ## notifications to any number of different applications from the same application
@@ -107,12 +107,27 @@ module PYAPNS
   ## searching for or comparing the token received in the hexadecimal form returned, 
   ## note that it's lowercase hex.
   ##
+  ## Retrieving Blacklist
+  ##
+  ## The pyapns maintains a blacklist that stores invalid tokens (i.e. sandbox 
+  ## tokens in production) Such invalid tokens cause a drop of the APNS connection.
+  ## PYAPNS will detect the invalid tokens causing a connection drop and add them
+  ## to a blacklist on an Application basis. The blacklist is used to filter out 
+  ## invalid tokens in order to prevent connection drops 
+  ## PYAPNS will return an Array of tokens:
+  ##
+  ##      blacklist = client.blacklist 'cf'
+  ##      => ['token', ... ]
+  ##
+  ## Note that once you query the blacklist, it will be removed so you need to ensure
+  ## that this tokens get de-provisioned from your push token list
+  ##  
   ## Asynchronous Calls
   ##
   ## PYAPNS::Client will, by default, perform no funny stuff and operate entirely
   ## within the calling thread. This means that certain applications may hang when,
   ## say, sending a notification, if only for a fraction of a second. Obviously 
-  ## not a desirable trait, all `provision`, `feedback` and `notify`
+  ## not a desirable trait, all `provision`, `feedback`, `blacklist` and `notify`
   ## methods also take a block, which indicates to the method you want to call
   ## PYAPNS asynchronously, and it will be done so handily in another thread, calling
   ## back your block with a single argument when finished. Note that `notify` and `provision`
@@ -158,6 +173,10 @@ module PYAPNS
 
     def feedback(*args, &block)
       perform_call :feedback, args, :app_id, &block
+    end
+    
+    def blacklist(*args, &block)
+      perform_call :blacklist, args, :app_id, &block
     end
 
     def perform_call(method, splat, *args, &block)


### PR DESCRIPTION
This is the more solid version of the token feedback patch.
It also includes XMLRPC methods for server and clients to fetch the blacklist (which will be cleared afterwards) in order to deprovision the tokens.
