### PR TITLE
Switched SSL method with APNS servers from SSL 3.0 to TLS1.0 because of ...

### DIFF
--- a/pyapns/server.py
+++ b/pyapns/server.py
@@ -54,7 +54,7 @@ class APNSClientContextFactory(ClientContextFactory):
       log.msg('APNSClientContextFactory ssl_cert_file=%s' % ssl_cert_file)
     else:
       log.msg('APNSClientContextFactory ssl_cert_file={FROM_STRING}')
-    self.ctx = SSL.Context(SSL.SSLv3_METHOD)
+    self.ctx = SSL.Context(SSL.TLSv1_METHOD)
     if 'BEGIN CERTIFICATE' in ssl_cert_file:
       cer = crypto.load_certificate(crypto.FILETYPE_PEM, ssl_cert_file)
       pkey = crypto.load_privatekey(crypto.FILETYPE_PEM, ssl_cert_file)


### PR DESCRIPTION
...Apple dropping support for SSL3.0

[Apple Announcement](https://developer.apple.com/news/?id=10222014a)
