### PR TITLE
Use TLSv1 instead of SSLv3

### DIFF
--- a/pyapns/server.py
+++ b/pyapns/server.py
@@ -59,7 +59,7 @@ class APNSClientContextFactory(ClientContextFactory):
                 'APNSClientContextFactory ssl_cert_file=%s' % ssl_cert_file)
         else:
             log.msg('APNSClientContextFactory ssl_cert_file={FROM_STRING}')
-        self.ctx = SSL.Context(SSL.SSLv3_METHOD)
+        self.ctx = SSL.Context(SSL.TLSv1_METHOD)
         if 'BEGIN CERTIFICATE' in ssl_cert_file:
             cer = crypto.load_certificate(crypto.FILETYPE_PEM, ssl_cert_file)
             pkey = crypto.load_privatekey(crypto.FILETYPE_PEM, ssl_cert_file)


### PR DESCRIPTION
 I had previously been using master and I know this was done there, but now I'm trying out the v50 improvements.  I'm not sure if you're still maintaining this branch or if you ever plan to merge it in to mater at all, but I figured I'd send this simple change your way so that others trying out v50 can see that they will also need to do this. This came back to bite me just like it did a year ago when I was using master.