### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Each of these functions can be called synchronously and asynchronously. To make 
 
 ## The Ruby API
 
-###PYAPNS::Client
+### PYAPNS::Client
 There's python in my ruby!
 
 The ruby gem can be installed from [here](https://github.com/krasio/pyapns_gem)
@@ -222,7 +222,7 @@ charge a fee each time you push a notification, and charge extra for so-called
 However, PYAPNS is free, as in beer and offers more scaling opportunities without
 the financial draw.
 
-###Provisioning
+### Provisioning
 
 To add your app to the PYAPNS server, it must be `provisioned` at least once.
 Normally this is done once upon the start-up of your application, be it a web
@@ -247,7 +247,7 @@ See the docs on `PYAPNS::ClientConfiguration` for a list of available configurat
 parameters (some of these are important, and you can specify initial applications)
 to be configured by default.
 
-###Sending Notifications
+### Sending Notifications
 
 Once your client is configured, and application provisioned (again, these
 should be taken care of before you write notification code) you can begin
@@ -275,7 +275,7 @@ converted to `PYAPNS::Notification` objects so they can be optimized for the wir
 (nil values removed, etc...), and you can pass `PYAPNS::Notification` objects
 directly if you wish.
 
-###Retrieving Feedback
+### Retrieving Feedback
 
 The APS service offers a feedback functionality that allows application servers
 to retrieve a list of device tokens it deems to be no longer in use, and the
@@ -286,7 +286,7 @@ with the date and the token:
 
     feedbacks = client.feedback 'cf'
 
-###Asynchronous Calls
+### Asynchronous Calls
 
 PYAPNS::Client will, by default, perform no funny stuff and operate entirely
 within the calling thread. This means that certain applications may hang when,
@@ -304,7 +304,7 @@ Just pass a block to provision/notify/feedback like so:
       feedbacks.each { |f| trim_token f }
     end
 
-###PYAPNS::ClientConfiguration
+### PYAPNS::ClientConfiguration
 A middleware class to make `PYAPNS::Client` easy to use in web contexts
 
 Automates configuration of the client in Rack environments
@@ -340,7 +340,7 @@ Where the configuration variables are defined:
     :timoeut  Number      The timeout for the server to use when connecting
                           to the apple servers
 
-###PYAPNS::Notification
+### PYAPNS::Notification
 An APNS Notification
 
 You can construct notification objects ahead of time by using this class.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
